### PR TITLE
Remove outdated Trello link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 - [:speaker: Developer Slack ](https://developer.starlingbank.com/community) – Ask questions, post suggestions, whatever!
 - [:octocat: Starling's Github](https://github.com/starlingbank) – Our current open-source offerings to help you connect.
 - [:warning: Service Status](https://starlingbank.statuspage.io/) – Is it just me?
-- [:rocket: Trello Roadmap](https://trello.com/b/wp8bOZPL/starling-developers-roadmap) - See what we're working on.
 
 ## News & Updates
 #### 23rd November 2017


### PR DESCRIPTION
The link goes to a 404 