### PR TITLE
Add starling-rs to list of SDKs/libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - [Official Javascript SDK](https://github.com/starlingbank/starling-developer-sdk): Official SDK written in JavaScript
 - [Java](https://github.com/deepinspire/Simple-SDK-for-Starling-API-v2/): An unofficial Java library for using the Starling API – Credit to [deepinspire](https://github.com/deepinspire)
 - [.NET Standard](https://github.com/Netizine/StarlingBankClient): An unofficial .Net library for using the Starling API – Credit to [Netizine](https://github.com/Netizine)
+- [Rust](https://github.com/shymega/starling-rs): An unofficial Rust SDK for using the Starling API - Credit to [shymega](https://github.com/shymega)
 
 ## Starter Kits
 


### PR DESCRIPTION
This commit adds my unofficial Rust SDK to the list of SDKs/libraries for Starling Bank's API. 

Please bear in mind that this SDK is in work-in-progress, and has not had any release yet. It will be published to [crates.io](https://crates.io) when ready.

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>